### PR TITLE
declare the "log" option in an "export" block so it can be overriden with a redef

### DIFF
--- a/scripts/CVE_2021_44228.zeek
+++ b/scripts/CVE_2021_44228.zeek
@@ -36,7 +36,9 @@ type PayloadParts: record {
 
 # Very general, FPs expected but we're casting a wide net intentionally.
 global exploit_pattern: pattern = /\$\{/;
-option log = T;
+export {
+    option log = T;
+}
 
 # If split doesn't return the expected number of indices, return the default "-"
 function safe_split1_w_default(s: string, p: pattern, idx: count, missing: string &default="-"): string


### PR DESCRIPTION
declare the "log" option in an "export" block so it can be overriden with a redef

Signed-off-by: SG <13872653+mmguero@users.noreply.github.com>