### PR TITLE
Always create the log stream

### DIFF
--- a/scripts/CVE_2021_44228.zeek
+++ b/scripts/CVE_2021_44228.zeek
@@ -291,6 +291,5 @@ event signature_match(state: signature_state, msg: string, data: string)
 
 event zeek_init() &priority=5
     {
-    if ( log )
-        Log::create_stream(CVE_2021_44228::LOG, [$columns=Info, $path="log4j"]);
+    Log::create_stream(CVE_2021_44228::LOG, [$columns=Info, $path="log4j"]);
     }


### PR DESCRIPTION
In the event that the configuration options are received after zeek_init
is generated logs won't work.  This fixes it by always creating the log
stream regardless of the setting.