### PR TITLE
Update notice content for Zeek 4.2

### DIFF
--- a/scripts/CVE_2021_44228_java_GET.zeek
+++ b/scripts/CVE_2021_44228_java_GET.zeek
@@ -38,7 +38,7 @@ event http_header(c: connection, is_orig: bool, name: string, value: string)
                     $identifier=cat(c$id$orig_h,c$id$orig_p,c$id$resp_h,c$id$resp_p),
                     # $suppress_for=3600sec,
                     $msg=fmt("Possible Log4j CVE-2021-44228 exploit, Java has downloaded a Java class over HTTP indicating a potential second stage, after the primary LDAP request. Refer to sub field for user_agent and mime-type"),
-                    $sub=fmt("user_agent='%s', CONTENT-TYPE='%s', host='%s'", c$http$user_agent, c$http$CVE_2021_44228_content_type, c$http$host)]);
+                    $sub=fmt("user_agent='%s', CONTENT-TYPE='%s', host='%s'", c$http$user_agent, c$http$CVE_2021_44228_content_type, split_string1(c$http$host, /:/)[0])]);
             }
         }
     }


### PR DESCRIPTION
The HTTP host header does not have the :port field removed in Zeek 4.2.
This change removes the :port part of the host header, making the script
output backward-compatible with previous versions of Zeek.